### PR TITLE
Use binja-test-mocks only in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
 
     - name: Install uv
       uses: astral-sh/setup-uv@v4

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/binja-test-mocks"]
-	path = vendor/binja-test-mocks
-	url = git@github.com:mblsha/binja-test-mocks.git

--- a/__init__.py
+++ b/__init__.py
@@ -1,51 +1,47 @@
+from __future__ import annotations
+
+import importlib.util
 import os
 import sys
 from pathlib import Path
 
-# Add plugin directory to path for imports
-plugin_dir = str(Path(__file__).resolve().parent)
-if plugin_dir not in sys.path:
-    sys.path.insert(0, plugin_dir)
+_plugin_dir = Path(__file__).resolve().parent
+_plugin_dir_str = str(_plugin_dir)
 
-# Load mock API for testing if requested
-if os.environ.get("FORCE_BINJA_MOCK") == "1":
-    from binja_test_mocks import binja_api  # noqa: F401
-
-import binaryninja
-
-try:
-    from .ColecoView import ColecoView
-    from .RelView import RelView
-    from .SharpPCG850View import SharpPCG850View, Z80PCG850Arch
-    from .Z80Arch import Z80
-except ImportError:
-    # Test context - use absolute imports
-    from ColecoView import ColecoView
-    from RelView import RelView
-    from SharpPCG850View import SharpPCG850View, Z80PCG850Arch
-    from Z80Arch import Z80
-
-# Register all components
-Z80.register()
-ColecoView.register()
-Z80PCG850Arch.register()
-SharpPCG850View.register()
-RelView.register()
-
-# built-in view
-EM_Z80 = 220
-binaryninja.BinaryViewType["ELF"].register_arch(
-    EM_Z80, binaryninja.enums.Endianness.LittleEndian, binaryninja.Architecture["Z80"]
-)
+# Ensure the plugin directory is importable when loaded directly by Binary Ninja.
+if _plugin_dir_str not in sys.path:
+    sys.path.insert(0, _plugin_dir_str)
 
 
-class ParametersInRegistersCallingConvention(binaryninja.CallingConvention):
-    name = "ParametersInRegisters"
-    # int_return_reg = 'A'
+def module_exists(module_name: str) -> bool:
+    if module_name in sys.modules:
+        return True
+    try:
+        return importlib.util.find_spec(module_name) is not None
+    except (ValueError, ImportError):
+        return False
 
 
-arch = binaryninja.Architecture["Z80"]
-arch.register_calling_convention(ParametersInRegistersCallingConvention(arch, "default"))
+def _running_inside_binary_ninja() -> bool:
+    try:
+        if module_exists("binaryninjaui"):
+            return True
+    except Exception:
+        pass
 
-arch = binaryninja.Architecture["Z80 PC-G850"]
-arch.register_calling_convention(ParametersInRegistersCallingConvention(arch, "default"))
+    exe = (sys.executable or "").lower()
+    if "binary ninja.app" in exe:
+        return True
+    return os.path.basename(exe) in ("binaryninja", "binaryninja.exe")
+
+
+_force_mock_requested = os.environ.get("FORCE_BINJA_MOCK", "").lower() in ("1", "true", "yes")
+_running_binja = _running_inside_binary_ninja()
+_skip_registration = _force_mock_requested and not _running_binja
+
+_has_binaryninja = module_exists("binaryninja")
+
+if _has_binaryninja and __package__ and not _skip_registration:
+    from ._bn_plugin import register
+
+    register(plugin_dir=_plugin_dir)

--- a/_bn_plugin.py
+++ b/_bn_plugin.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def register(*, plugin_dir: Path) -> None:
+    import binaryninja
+
+    try:
+        from .ColecoView import ColecoView
+        from .RelView import RelView
+        from .SharpPCG850View import SharpPCG850View, Z80PCG850Arch
+        from .Z80Arch import Z80
+    except ImportError:
+        from ColecoView import ColecoView
+        from RelView import RelView
+        from SharpPCG850View import SharpPCG850View, Z80PCG850Arch
+        from Z80Arch import Z80
+
+    Z80.register()
+    ColecoView.register()
+    Z80PCG850Arch.register()
+    SharpPCG850View.register()
+    RelView.register()
+
+    # built-in view
+    EM_Z80 = 220
+    binaryninja.BinaryViewType["ELF"].register_arch(
+        EM_Z80, binaryninja.enums.Endianness.LittleEndian, binaryninja.Architecture["Z80"]
+    )
+
+    class ParametersInRegistersCallingConvention(binaryninja.CallingConvention):
+        name = "ParametersInRegisters"
+
+    arch = binaryninja.Architecture["Z80"]
+    arch.register_calling_convention(ParametersInRegistersCallingConvention(arch, "default"))
+
+    arch = binaryninja.Architecture["Z80 PC-G850"]
+    arch.register_calling_convention(ParametersInRegistersCallingConvention(arch, "default"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,15 +29,14 @@ classifiers = [
 
 dependencies = [
     "z80dis>=1.0.4",
-    "binja-test-mocks>=0.1.4",  # Architecture registry fixes included
 ]
 
 # Dev dependencies are now in [tool.uv] section
 
 [project.urls]
-"Homepage" = "https://github.com/yourusername/binja-z80"
-"Bug Tracker" = "https://github.com/yourusername/binja-z80/issues"
-"Documentation" = "https://github.com/yourusername/binja-z80/blob/main/README.md"
+"Homepage" = "https://github.com/mblsha/Z80"
+"Bug Tracker" = "https://github.com/mblsha/Z80/issues"
+"Documentation" = "https://github.com/mblsha/Z80/blob/opcode_bundle_2-master/README.md"
 
 [tool.hatch.build.targets.wheel]
 packages = ["."]
@@ -109,6 +108,7 @@ ignore_missing_imports = false
 
 [tool.uv]
 dev-dependencies = [
+    "binja-test-mocks>=0.1.10",
     "pytest>=7.4.0",
     "pytest-cov>=4.1.0",
     "pytest-timeout>=2.1.0",

--- a/tests/README.md
+++ b/tests/README.md
@@ -10,11 +10,11 @@ This directory contains tests for the Z80 Binary Ninja plugin using `binja-test-
 # Using fish shell
 fish run-tests.fish
 
-# Using pytest directly
-FORCE_BINJA_MOCK=1 pytest
+# With uv (recommended)
+uv run pytest
 
-# With coverage
-FORCE_BINJA_MOCK=1 pytest --cov
+# Using pytest directly (tests/conftest.py enables mocks automatically)
+pytest
 ```
 
 ### Setup Virtual Environment
@@ -37,13 +37,5 @@ pip install pytest pytest-cov
 
 ## Writing New Tests
 
-All test files should start with:
-
-```python
-import os
-os.environ["FORCE_BINJA_MOCK"] = "1"
-
-from binja_test_mocks import binja_api  # noqa: F401
-```
-
-This ensures the mock API is loaded before importing any Binary Ninja modules.
+Do not set `FORCE_BINJA_MOCK` or import `binja_test_mocks.binja_api` in each test file.
+`tests/conftest.py` installs the mock API once for the entire test run.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,62 +1,56 @@
 """Pytest configuration for Z80 plugin tests."""
 
+from __future__ import annotations
+
+import importlib.util
 import os
 import sys
 from pathlib import Path
 
-# Ensure FORCE_BINJA_MOCK is set before any imports
-os.environ["FORCE_BINJA_MOCK"] = "1"
-
-# Add plugin directory to Python path
-plugin_dir = Path(__file__).parent.parent
-if str(plugin_dir) not in sys.path:
-    sys.path.insert(0, str(plugin_dir))
-
-# Import mock API before anything else
 import pytest
 
-# Import Binary Ninja components after mock setup
-from binaryninja import Architecture
-from binja_test_mocks import binja_api  # noqa: F401
+
+def _running_inside_binary_ninja() -> bool:
+    try:
+        return importlib.util.find_spec("binaryninjaui") is not None
+    except (ValueError, ImportError):
+        return False
+
+
+if not _running_inside_binary_ninja():
+    os.environ.setdefault("FORCE_BINJA_MOCK", "1")
+
+    # Import mock API before importing anything from `binaryninja`.
+    from binja_test_mocks import (
+        binja_api,  # noqa: F401  # pyright: ignore
+        mock_llil,
+    )
+
+    mock_llil.set_size_lookup({1: ".b", 2: ".w"}, {"b": 1, "w": 2})
+
+
+# Make the plugin importable as a package (`import Z80`) like Binary Ninja does.
+_plugin_dir = Path(__file__).resolve().parents[1]
+_plugins_parent = _plugin_dir.parent
+if str(_plugins_parent) not in sys.path:
+    sys.path.insert(0, str(_plugins_parent))
 
 
 @pytest.fixture(scope="session", autouse=True)
-def setup_plugin_registration():
-    """Register the Z80 plugin for all tests."""
-    # sitecustomize.py already patched the mocks, so registration is now meaningful.
-    # Clear any existing registrations for test isolation
+def setup_plugin_registration() -> None:
+    """Register the Z80 plugin for all tests (using the mock Binary Ninja API)."""
+    from binaryninja import Architecture
+
     if hasattr(Architecture, "clear_registry"):
         Architecture.clear_registry()
 
-    # Import and register the Z80 plugin
-    # This will run the registration code in __init__.py
-    import __init__  # noqa: F401
+    from Z80._bn_plugin import register
 
-    # Verify that the plugin registration actually worked
-    try:
-        arch = Architecture["Z80"]
-        assert hasattr(
-            arch, "get_instruction_info"
-        ), "Z80 architecture missing get_instruction_info"
-        assert hasattr(
-            arch, "get_instruction_text"
-        ), "Z80 architecture missing get_instruction_text"
-        print(f"✅ Z80 plugin registered successfully: {type(arch).__name__}")
-    except Exception as e:
-        pytest.fail(f"Failed to register Z80 plugin: {e}")
+    register(plugin_dir=_plugin_dir)
 
 
 @pytest.fixture
 def z80_arch():
-    """Get the registered Z80 architecture instance."""
+    from binaryninja import Architecture
+
     return Architecture["Z80"]
-
-
-@pytest.fixture
-def clear_arch_registry():
-    """Clear architecture registry for test isolation."""
-    if hasattr(Architecture, "clear_registry"):
-        Architecture.clear_registry()
-    yield
-    if hasattr(Architecture, "clear_registry"):
-        Architecture.clear_registry()

--- a/tests/test_disasm.py
+++ b/tests/test_disasm.py
@@ -2,16 +2,10 @@
 """Test Z80 disassembly against expected output."""
 
 import os
-
-os.environ["FORCE_BINJA_MOCK"] = "1"
-
 import re
 from pathlib import Path
 
 from binaryninja import Architecture
-from binja_test_mocks import binja_api  # noqa: F401
-
-# Import after setting up mocks
 
 
 def disasm_binja(data, addr):
@@ -84,13 +78,11 @@ def test_z80_disassembly():
 
 def test_specific_instructions():
     """Test specific Z80 instructions."""
-    import os
-
     # Test NOP
     assert disasm_binja(b"\x00\x00\x00\x00", 0) == "NOP"
 
     # Test LD instructions - use format based on compatibility mode
-    if os.environ.get("FORCE_BINJA_MOCK") == "1":
+    if os.environ.get("FORCE_BINJA_MOCK", "").lower() in ("1", "true", "yes"):
         # Compatibility mode uses $xx format
         assert disasm_binja(b"\x3e\x42\x00\x00", 0) == "LD A,$42"
         assert disasm_binja(b"\x01\x34\x12\x00", 0) == "LD BC,$1234"

--- a/tests/test_il_lifting.py
+++ b/tests/test_il_lifting.py
@@ -1,18 +1,11 @@
 #!/usr/bin/env python
 """Test Z80 IL lifting functionality."""
 
-import os
-
-os.environ["FORCE_BINJA_MOCK"] = "1"
-
 from binaryninja import Architecture
-from binja_test_mocks import binja_api  # noqa: F401
 from binja_test_mocks.mock_llil import MockLowLevelILFunction
 
 # Import Z80-specific test helpers
 from .test_helpers import get_operations
-
-# Import after setting up mocks
 
 
 def get_lifted_il(data, addr=0x1000):

--- a/uv.lock
+++ b/uv.lock
@@ -4,11 +4,11 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "binja-test-mocks"
-version = "0.1.4"
+version = "0.1.10"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/99/30/f0fb3fe93697a88ca30ebd0cc1a82d7d35f1e83d940588d77a5cd93ec887/binja_test_mocks-0.1.4.tar.gz", hash = "sha256:bc8ca0b5dff0b82c27608d091a7742ae0113b5fd549d9c766dcc9f953775a7fd", size = 22437 }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/7c/e06ce363829d2ad44fbe606a06ce4e4eb853acad4b24e4c2ab358fc5b18c/binja_test_mocks-0.1.10.tar.gz", hash = "sha256:7e2c9336db57c48dd6cb053737694f367b4baa7b9fdfa4f66c93a5f64498ad1b", size = 24845 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/76/5327e199eec9956b62e797abc95d3addaab7bc3104f8ee193dd5ed2a5e4f/binja_test_mocks-0.1.4-py3-none-any.whl", hash = "sha256:1130ff5ab0be8dacd81c916e03bb50b444311a5c99f8e302a95a0858aa1de2e9", size = 26793 },
+    { url = "https://files.pythonhosted.org/packages/81/e8/292b63f73a8cd3fef51d228950ee6d95485e53f44d899ee8713dda546acc/binja_test_mocks-0.1.10-py3-none-any.whl", hash = "sha256:cfb1d54723d86dca490c15fca486e0854c8e9af46b562f78278028d23a633af7", size = 28278 },
 ]
 
 [[package]]
@@ -16,12 +16,12 @@ name = "binja-z80"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "binja-test-mocks" },
     { name = "z80dis" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "binja-test-mocks" },
     { name = "black" },
     { name = "isort" },
     { name = "mypy" },
@@ -33,13 +33,11 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "binja-test-mocks", specifier = ">=0.1.4" },
-    { name = "z80dis", specifier = ">=1.0.4" },
-]
+requires-dist = [{ name = "z80dis", specifier = ">=1.0.4" }]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "binja-test-mocks", specifier = ">=0.1.10" },
     { name = "black", specifier = ">=23.7.0" },
     { name = "isort", specifier = ">=5.12.0" },
     { name = "mypy", specifier = ">=1.5.0" },


### PR DESCRIPTION
- Stop importing `binja_test_mocks.binja_api` from the plugin runtime (`__init__.py` now gates registration and calls `._bn_plugin.register()` only when running inside Binary Ninja).
- Add `tests/conftest.py` bootstrap that installs mocks early and registers the plugin for tests.
- Move `binja-test-mocks` to `uv` dev-dependencies, bump to `>=0.1.10`, and update `uv.lock`.
- Remove the vendored `vendor/binja-test-mocks` submodule and drop submodule checkout from CI.
